### PR TITLE
style: address upstream review findings

### DIFF
--- a/judge.default.toml
+++ b/judge.default.toml
@@ -14,10 +14,10 @@ api_base = "http://localhost:8317/v1/chat/completions"
 
 models = ["gpt-mini", "spark", "gemini-flash"]
 
-batch_size  = 10    # items per API call
-concurrency = 6     # parallel batch workers
-timeout     = 90    # seconds per HTTP request
-max_retries = 3     # retries per model before fallback
+batch_size  = 10    # Items per API call.
+concurrency = 6     # Parallel batch workers.
+timeout     = 90    # Seconds per HTTP request.
+max_retries = 3     # Retries per model before fallback.
 
 [pricing]   # USD per 1M tokens: [input, output]
 gpt-mini      = [0.15, 0.60]

--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -26,7 +26,7 @@ class PendingScore:
         kl_divergence: float,
         responses: list[str],
         judge_future: Future[list[bool] | None] | None,
-    ):
+    ) -> None:
         self._evaluator = evaluator
         self.kl_divergence = kl_divergence
         self._responses = responses
@@ -105,7 +105,7 @@ class Evaluator:
     base_logprobs: Tensor
     base_refusals: int
 
-    def __init__(self, settings: Settings, model: Model):
+    def __init__(self, settings: Settings, model: Model) -> None:
         self.settings = settings
         self.model = model
         self._judge_executor = ThreadPoolExecutor(max_workers=1)

--- a/src/heretic/llm_judge.py
+++ b/src/heretic/llm_judge.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
 
 """LLM judge for refusal classification via local API router.
 

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -657,33 +657,40 @@ def run():
             study.tell(current_trial, state=TrialState.FAIL)
             current_trial = None
 
-    try:
-        n_remaining = settings.n_trials - count_completed_trials()
-        for _ in range(n_remaining):
-            current_trial = study.ask()
-            trial_index += 1
-            current_trial.set_user_attr("index", trial_index)
-
-            suggest_and_abliterate(current_trial, trial_index)
-
-            print("* Evaluating...")
-            new_pending = evaluator.start_evaluation()
-
-            # Resolve PREVIOUS trial's LLM judge (ran during this trial's GPU work)
-            resolve_pending(pending)
-
-            pending = (new_pending, current_trial, trial_index)
-            current_trial = None  # Now tracked via pending
-
-        # Flush last trial
-        resolve_pending(pending)
+    def _run_trial_loop() -> None:
+        """Execute pipelined ask/tell loop for remaining trials."""
+        nonlocal pending, current_trial, trial_index
         pending = None
+        current_trial = None
+        try:
+            n_remaining = settings.n_trials - count_completed_trials()
+            for _ in range(n_remaining):
+                current_trial = study.ask()
+                trial_index += 1
+                current_trial.set_user_attr("index", trial_index)
 
-    except KeyboardInterrupt:
-        _fail_outstanding_trials()
-    except Exception:
-        _fail_outstanding_trials()
-        raise
+                suggest_and_abliterate(current_trial, trial_index)
+
+                print("* Evaluating...")
+                new_pending = evaluator.start_evaluation()
+
+                # Resolve PREVIOUS trial's LLM judge (ran during this trial's GPU work).
+                resolve_pending(pending)
+
+                pending = (new_pending, current_trial, trial_index)
+                current_trial = None  # Now tracked via pending.
+
+            # Flush last trial.
+            resolve_pending(pending)
+            pending = None
+
+        except KeyboardInterrupt:
+            _fail_outstanding_trials()
+        except Exception:
+            _fail_outstanding_trials()
+            raise
+
+    _run_trial_loop()
 
     if count_completed_trials() == settings.n_trials:
         study.set_user_attr("finished", True)
@@ -779,27 +786,7 @@ def run():
                 study.set_user_attr("settings", settings.model_dump_json())
                 study.set_user_attr("finished", False)
 
-                pending = None
-                current_trial = None
-                try:
-                    n_extra = settings.n_trials - count_completed_trials()
-                    for _ in range(n_extra):
-                        current_trial = study.ask()
-                        trial_index += 1
-                        current_trial.set_user_attr("index", trial_index)
-                        suggest_and_abliterate(current_trial, trial_index)
-                        print("* Evaluating...")
-                        new_pending = evaluator.start_evaluation()
-                        resolve_pending(pending)
-                        pending = (new_pending, current_trial, trial_index)
-                        current_trial = None
-                    resolve_pending(pending)
-                    pending = None
-                except KeyboardInterrupt:
-                    _fail_outstanding_trials()
-                except Exception:
-                    _fail_outstanding_trials()
-                    raise
+                _run_trial_loop()
 
                 if count_completed_trials() == settings.n_trials:
                     study.set_user_attr("finished", True)

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2025-2026  Philipp Emanuel Weidmann <pew@worldwidemann.com> + contributors
+
 """Tests for LLM judge utility functions.
 
 Covers prompt/response boundary construction, tag sanitization,


### PR DESCRIPTION
## Summary

- Apply all 6 style fixes from gemini-code-assist review on p-e-w/heretic#255
- TOML comment capitalization and punctuation per upstream styleguide rule #4
- Add `-> None` return type to `__init__` methods per rule #5
- Add SPDX/Copyright headers to new Python files per rule #6
- Extract `_run_trial_loop()` to eliminate duplicated trial execution block

## Test plan

- [x] `uv run ruff format --check .` — pass
- [x] `uv run ruff check --extend-select I .` — pass
- [x] `uv run ty check --error-on-warning .` — pass
- [x] `uv build` — pass
- [x] `uv run pytest tests/` — 38 passed
- [x] `csa review --branch main` — APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)