### PR TITLE
feat: support template-controlled thinking models

### DIFF
--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -294,7 +294,9 @@ class Evaluator:
         try:
             self.model.response_prefix = ""
             responses = self.model.get_responses_batched(
-                prompts, skip_special_tokens=False
+                prompts,
+                skip_special_tokens=False,
+                enable_thinking=True if profile.template_controlled else None,
             )
         finally:
             self.model.response_prefix = original_prefix
@@ -304,10 +306,16 @@ class Evaluator:
             if not response.strip():
                 failures += 1
                 continue
-            open_pos = response.find(profile.opening_marker)
             close_pos = response.find(profile.completion_marker)
-            if open_pos < 0 or close_pos < 0 or close_pos <= open_pos:
-                failures += 1
+            if profile.template_controlled:
+                # Template-controlled models (e.g. Qwen3.5) put <think> in the
+                # input via the chat template; only </think> appears in output.
+                if close_pos < 0:
+                    failures += 1
+            else:
+                open_pos = response.find(profile.opening_marker)
+                if open_pos < 0 or close_pos < 0 or close_pos <= open_pos:
+                    failures += 1
 
         total = len(prompts)
         rate = (total - failures) / total if total > 0 else 0.0

--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -503,6 +503,27 @@ def run():
             model.response_prefix += additional_prefix
             print(f"* Extended prefix found: [bold]{model.response_prefix!r}[/]")
 
+    # Fallback: detect thinking model from chat template (e.g. Qwen3.5).
+    # These models control thinking via the template's enable_thinking parameter
+    # rather than emitting <think> as part of the model output.
+    if (
+        model.thinking_profile is None
+        and hasattr(model.tokenizer, "chat_template")
+        and model.tokenizer.chat_template
+        and "enable_thinking" in model.tokenizer.chat_template
+    ):
+        model.thinking_profile = ThinkingProfile(
+            name="think",
+            opening_marker="<think>",
+            completion_marker="</think>",
+            suppressed_prefix="<think></think>",
+            template_controlled=True,
+        )
+        print(
+            "* Thinking model detected from chat template "
+            f"(profile: [bold]{model.thinking_profile.name}[/], template-controlled)"
+        )
+
     if settings.thinking_eval_enabled and model.thinking_profile is None:
         print(
             "[yellow]Warning:[/] thinking_eval_enabled is true but no supported "

--- a/src/heretic/model.py
+++ b/src/heretic/model.py
@@ -52,6 +52,7 @@ class ThinkingProfile:
     opening_marker: str
     completion_marker: str
     suppressed_prefix: str
+    template_controlled: bool = False
 
 
 @dataclass
@@ -555,6 +556,7 @@ class Model:
     def generate(
         self,
         prompts: list[Prompt],
+        enable_thinking: bool | None = None,
         **kwargs: Any,
     ) -> tuple[BatchEncoding, GenerateDecoderOnlyOutput | LongTensor]:
         chats = [
@@ -565,6 +567,10 @@ class Model:
             for prompt in prompts
         ]
 
+        template_kwargs: dict[str, Any] = {}
+        if enable_thinking is not None:
+            template_kwargs["enable_thinking"] = enable_thinking
+
         # This cast is valid because list[str] is the return type
         # for batched operation with tokenize=False.
         chat_prompts = cast(
@@ -573,6 +579,7 @@ class Model:
                 chats,
                 add_generation_prompt=True,
                 tokenize=False,
+                **template_kwargs,
             ),
         )
 
@@ -603,10 +610,12 @@ class Model:
         self,
         prompts: list[Prompt],
         skip_special_tokens: bool = False,
+        enable_thinking: bool | None = None,
     ) -> list[str]:
         inputs, outputs = self.generate(
             prompts,
             max_new_tokens=self.settings.max_response_length,
+            enable_thinking=enable_thinking,
         )
 
         return self.tokenizer.batch_decode(
@@ -621,6 +630,7 @@ class Model:
         self,
         prompts: list[Prompt],
         skip_special_tokens: bool = False,
+        enable_thinking: bool | None = None,
     ) -> list[str]:
         responses = []
 
@@ -628,6 +638,7 @@ class Model:
             for response in self.get_responses(
                 batch,
                 skip_special_tokens=skip_special_tokens,
+                enable_thinking=enable_thinking,
             ):
                 responses.append(response)
 


### PR DESCRIPTION
## Summary
- Add `template_controlled` field to `ThinkingProfile` for models like Qwen3.5 that control thinking via chat template `enable_thinking` parameter rather than output prefixes
- Thread `enable_thinking` parameter through `generate()`, `get_responses()`, `get_responses_batched()`
- Add fallback detection from chat template for models without `<think>` prefix in output
- Update `evaluate_thinking()` to handle template-controlled models (only check `</think>` in output, not `<think>`)

## Test plan
- [ ] Verify Qwen3.5 thinking detection works via chat template fallback
- [ ] Verify non-template-controlled models still work (prefix-based detection)
- [ ] CI passes (format, lint, typecheck, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)