### PR TITLE
fix: CUDA cache cleanup after OOM + geometric median device mismatch

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -456,6 +456,7 @@ def run():
                     # We cannot recover from this.
                     raise
 
+                empty_cache()
                 print(f"[red]Failed[/] ({error})")
                 break
 
@@ -574,12 +575,13 @@ def run():
             ) from None
 
         def _per_layer_geometric_median(residuals: torch.Tensor) -> torch.Tensor:
+            device = residuals.device
             return torch.stack(
                 [
                     compute_geometric_median(residuals[:, i, :].detach().cpu()).median
                     for i in range(residuals.shape[1])
                 ]
-            )
+            ).to(device)
 
         good_center = _per_layer_geometric_median(good_residuals)
         bad_center = _per_layer_geometric_median(bad_residuals)

--- a/uv.lock
+++ b/uv.lock
@@ -947,6 +947,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "questionary" },
     { name = "rich" },
+    { name = "tqdm" },
     { name = "transformers" },
 ]
 
@@ -996,6 +997,7 @@ requires-dist = [
     { name = "rich", specifier = "~=14.3" },
     { name = "scikit-learn", marker = "extra == 'research'", specifier = "~=1.7" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'llm-judge'", specifier = ">=2" },
+    { name = "tqdm", specifier = "~=4.67" },
     { name = "transformers", specifier = "~=5.3" },
 ]
 provides-extras = ["llm-judge", "research"]


### PR DESCRIPTION
## Summary
- Add `empty_cache()` after OOM during batch size auto-detection to prevent stale CUDA allocations from polluting subsequent attempts (Closes #19)
- Preserve input tensor device in `_per_layer_geometric_median()` by saving `residuals.device` and calling `.to(device)` on result, preventing CPU/GPU mismatch when using `geometric_median` direction method (Closes #20)

## Test plan
- [ ] Verify batch size auto-detection on low-VRAM system with high max_batch_size triggers OOM → cache is cleaned → next inference succeeds
- [ ] Verify `direction_method = "geometric_median"` produces directions on same device as input residuals
- [ ] Run full optimization loop with geometric_median to confirm no device mismatch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)