### PR TITLE
feat: cache sequence KL baseline across runs

### DIFF
--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -22,6 +22,9 @@ from .utils import Prompt, format_duration, load_prompts, print
 
 logger = logging.getLogger(__name__)
 
+# Bump this when cache-affecting logic changes (generation, logprobs, serialization).
+_CACHE_VERSION = 1
+
 
 @dataclass(frozen=True)
 class TrialEvaluation:
@@ -347,6 +350,7 @@ class Evaluator:
             else self.settings.system_prompt
         )
         key_data = {
+            "cache_version": _CACHE_VERSION,
             "model": self.settings.model,
             "quantization": self.settings.quantization.value,
             "kl_sequence_length": self.settings.kl_sequence_length,


### PR DESCRIPTION
## Summary

- Cache sequence KL baseline artifacts (`reference_ids`, `reference_mask`, base logprobs memmap) to `checkpoints/kl_baseline_{hash}.{pt,dat}`
- Cache key is SHA-256 of: model name, quantization, `kl_sequence_length`, `max_good_eval_prompts`, dataset specification, and resolved system prompt
- On cache hit, skip `generate_reference_ids()` and `save_sequence_logprobs_to_disk()` entirely — reduces repeat startup from **30+ minutes to seconds** on ARM CPU
- Cached files are persistent (no atexit cleanup); users can delete manually to invalidate

Closes #31

## Test plan

- [ ] Verify first run with `kl_mode = "sequence"` generates and caches baseline to `checkpoints/` directory
- [ ] Verify second run with same config loads from cache ("Loaded cached" message)
- [ ] Verify changing any cache key component (model, kl_sequence_length, dataset, etc.) triggers regeneration
- [ ] Verify corrupted/missing cache files are handled gracefully (fallback to regeneration)
- [ ] Verify `kl_mode = "single_token"` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)