### PR TITLE
chore: gitignore local artifacts and update weave.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ wheels/
 
 # Residual plots
 /plots/
+
+# Local overrides
+/uv.toml
+
+# Test artifacts
+.test
+*.db

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "ca0e7f6602baad5c40b23c73c69848e461b77c67"
+commit = "46eabd606bb5010a65fd21ee1eae573b9bb8838d"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Add `uv.toml`, `.test`, and `*.db` to `.gitignore` (local-only artifacts)
- Update `weave.lock` pin

## Test plan

- [x] `git check-ignore` confirms new patterns match intended files
- [x] No tracked files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)