### PR TITLE
perf: exclude batch_size from residual cache hash key

### DIFF
--- a/src/heretic/main.py
+++ b/src/heretic/main.py
@@ -121,7 +121,6 @@ def _get_residual_cache_metadata(
         "loaded_model": getattr(model_config, "name_or_path", None),
         "commit_hash": getattr(model_config, "_commit_hash", None),
         "quantization": settings.quantization.value,
-        "batch_size": settings.batch_size,
         "winsorization_quantile": settings.winsorization_quantile,
         "good_dataset_path": settings.good_prompts.dataset,
         "good_dataset_checksum": _hash_prompt_dataset(good_prompts),

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "3ad54bd580648e92e867f60d9686dee8e81fc0ee"
+commit = "f1863c1d2321e662602c1523f701f33c2d3a9f2b"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Removes `batch_size` from residual cache hash key computation in `_get_residual_cache_metadata()`
- `batch_size` only affects memory usage and computation speed, not the final residual values
- Prevents unnecessary cache invalidation when changing batch_size across machines

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)