### PR TITLE
feat(llm-judge): support configurable max_tokens and think parameter

### DIFF
--- a/judge.default.toml
+++ b/judge.default.toml
@@ -23,7 +23,7 @@ max_tokens  = 200   # Max tokens for judge API responses.
                     # Thinking models (e.g. Gemma 4) may consume this budget
                     # with reasoning tokens, leaving content empty. Increase
                     # when using such models.
-                    # Env var: LLM_JUDGE_MAX_TOKENS
+                    # Env var: LLM_JUDGE_MAX_TOKENS.
 
 # Optional "think" parameter sent in the API request payload.
 # Some API routers use this to control reasoning/thinking behavior.

--- a/judge.default.toml
+++ b/judge.default.toml
@@ -5,7 +5,8 @@
 # Env var mapping:
 #   LLM_JUDGE_API_BASE, LLM_JUDGE_API_KEY, LLM_JUDGE_MODELS (comma-separated),
 #   LLM_JUDGE_BATCH_SIZE, LLM_JUDGE_CONCURRENCY, LLM_JUDGE_TIMEOUT,
-#   LLM_JUDGE_MAX_RETRIES, LLM_JUDGE_PRICING (model:in:out,...)
+#   LLM_JUDGE_MAX_RETRIES, LLM_JUDGE_MAX_TOKENS, LLM_JUDGE_THINK,
+#   LLM_JUDGE_PRICING (model:in:out,...)
 #
 # Config file path can be changed via LLM_JUDGE_CONFIG env var (default: judge.toml).
 
@@ -18,6 +19,17 @@ batch_size  = 10    # Items per API call.
 concurrency = 6     # Parallel batch workers.
 timeout     = 90    # Seconds per HTTP request.
 max_retries = 3     # Retries per model before fallback.
+max_tokens  = 200   # Max tokens for judge API responses.
+                    # Thinking models (e.g. Gemma 4) may consume this budget
+                    # with reasoning tokens, leaving content empty. Increase
+                    # when using such models.
+                    # Env var: LLM_JUDGE_MAX_TOKENS
+
+# Optional "think" parameter sent in the API request payload.
+# Some API routers use this to control reasoning/thinking behavior.
+# Leave unset (commented out) to omit the parameter entirely.
+# Env var: LLM_JUDGE_THINK (empty string = unset).
+# think = "true"
 
 [pricing]   # USD per 1M tokens: [input, output].
 gpt-mini      = [0.15, 0.60]

--- a/src/heretic/llm_judge.py
+++ b/src/heretic/llm_judge.py
@@ -17,6 +17,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from typing import Any
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -253,7 +254,7 @@ def _load_config() -> JudgeConfig:
     if env_think:
         think = env_think
     elif "think" in file_cfg and file_cfg["think"]:
-        think = str(file_cfg["think"])
+        think = str(file_cfg["think"]).lower()
 
     return JudgeConfig(
         api_base=os.environ.get(
@@ -604,7 +605,7 @@ def _classify_individual_items(
 
 def _call_api(model: str, user_prompt: str, cfg: JudgeConfig) -> _ParsedBatchLabels:
     """Call API and return parsed R/N labels."""
-    payload: dict = {
+    payload: dict[str, Any] = {
         "model": model,
         "messages": [
             {

--- a/src/heretic/llm_judge.py
+++ b/src/heretic/llm_judge.py
@@ -70,6 +70,8 @@ class JudgeConfig:
     fallback_policy: str = "never"  # Options: 'never' or 'substring'.
     retry_strategy: str = "persistent"  # Options: 'persistent' or 'exponential'.
     retry_interval: int = 30  # Seconds between retries.
+    max_tokens: int = 200  # Max tokens for judge API responses.
+    think: str | None = None  # Thinking parameter for reasoning models.
 
 
 # ---------------------------------------------------------------------------
@@ -245,6 +247,14 @@ def _load_config() -> JudgeConfig:
         )
         retry_strategy_raw = "persistent"
 
+    # Think parameter: env var > TOML > None (disabled).
+    think: str | None = None
+    env_think = os.environ.get("LLM_JUDGE_THINK", "")
+    if env_think:
+        think = env_think
+    elif "think" in file_cfg and file_cfg["think"]:
+        think = str(file_cfg["think"])
+
     return JudgeConfig(
         api_base=os.environ.get(
             "LLM_JUDGE_API_BASE",
@@ -289,6 +299,13 @@ def _load_config() -> JudgeConfig:
             file_key="retry_interval",
             default=30,
         ),
+        max_tokens=_parse_positive_int(
+            file_cfg,
+            env_key="LLM_JUDGE_MAX_TOKENS",
+            file_key="max_tokens",
+            default=200,
+        ),
+        think=think,
     )
 
 
@@ -587,21 +604,24 @@ def _classify_individual_items(
 
 def _call_api(model: str, user_prompt: str, cfg: JudgeConfig) -> _ParsedBatchLabels:
     """Call API and return parsed R/N labels."""
+    payload: dict = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": cfg.system_prompt or _DEFAULT_SYSTEM_PROMPT,
+            },
+            {"role": "user", "content": user_prompt},
+        ],
+        "max_tokens": cfg.max_tokens,
+        "temperature": 0.0,
+    }
+    if cfg.think is not None:
+        payload["think"] = cfg.think
     resp = httpx.post(
         cfg.api_base,
         headers={"Authorization": f"Bearer {cfg.api_key}"},
-        json={
-            "model": model,
-            "messages": [
-                {
-                    "role": "system",
-                    "content": cfg.system_prompt or _DEFAULT_SYSTEM_PROMPT,
-                },
-                {"role": "user", "content": user_prompt},
-            ],
-            "max_tokens": 200,
-            "temperature": 0.0,
-        },
+        json=payload,
         timeout=cfg.timeout,
     )
     resp.raise_for_status()

--- a/src/heretic/llm_judge.py
+++ b/src/heretic/llm_judge.py
@@ -250,11 +250,11 @@ def _load_config() -> JudgeConfig:
 
     # Think parameter: env var > TOML > None (disabled).
     think: str | None = None
-    env_think = os.environ.get("LLM_JUDGE_THINK", "")
+    env_think = os.environ.get("LLM_JUDGE_THINK", "").strip().lower()
     if env_think:
         think = env_think
-    elif "think" in file_cfg and file_cfg["think"]:
-        think = str(file_cfg["think"]).lower()
+    elif "think" in file_cfg and file_cfg["think"] is not None:
+        think = str(file_cfg["think"]).strip().lower()
 
     return JudgeConfig(
         api_base=os.environ.get(

--- a/src/heretic/llm_judge.py
+++ b/src/heretic/llm_judge.py
@@ -64,6 +64,8 @@ class JudgeConfig:
     concurrency: int = _DEFAULT_CONCURRENCY
     timeout: int = _DEFAULT_TIMEOUT
     max_retries: int = _DEFAULT_MAX_RETRIES
+    max_tokens: int = 200  # Max tokens for judge API responses.
+    think: str | None = None  # Thinking parameter for reasoning models.
     pricing: dict[str, tuple[float, float]] = field(
         default_factory=lambda: dict(_DEFAULT_PRICING)
     )
@@ -71,8 +73,6 @@ class JudgeConfig:
     fallback_policy: str = "never"  # Options: 'never' or 'substring'.
     retry_strategy: str = "persistent"  # Options: 'persistent' or 'exponential'.
     retry_interval: int = 30  # Seconds between retries.
-    max_tokens: int = 200  # Max tokens for judge API responses.
-    think: str | None = None  # Thinking parameter for reasoning models.
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +290,13 @@ def _load_config() -> JudgeConfig:
             file_key="max_retries",
             default=_DEFAULT_MAX_RETRIES,
         ),
+        max_tokens=_parse_positive_int(
+            file_cfg,
+            env_key="LLM_JUDGE_MAX_TOKENS",
+            file_key="max_tokens",
+            default=200,
+        ),
+        think=think,
         pricing=pricing,
         system_prompt=system_prompt,
         fallback_policy=fallback_raw,
@@ -300,13 +307,6 @@ def _load_config() -> JudgeConfig:
             file_key="retry_interval",
             default=30,
         ),
-        max_tokens=_parse_positive_int(
-            file_cfg,
-            env_key="LLM_JUDGE_MAX_TOKENS",
-            file_key="max_tokens",
-            default=200,
-        ),
-        think=think,
     )
 
 

--- a/src/heretic/llm_judge.py
+++ b/src/heretic/llm_judge.py
@@ -65,7 +65,7 @@ class JudgeConfig:
     timeout: int = _DEFAULT_TIMEOUT
     max_retries: int = _DEFAULT_MAX_RETRIES
     max_tokens: int = 200  # Max tokens for judge API responses.
-    think: str | None = None  # Thinking parameter for reasoning models.
+    think: str | bool | None = None  # Thinking parameter for reasoning models.
     pricing: dict[str, tuple[float, float]] = field(
         default_factory=lambda: dict(_DEFAULT_PRICING)
     )
@@ -249,12 +249,19 @@ def _load_config() -> JudgeConfig:
         retry_strategy_raw = "persistent"
 
     # Think parameter: env var > TOML > None (disabled).
-    think: str | None = None
-    env_think = os.environ.get("LLM_JUDGE_THINK", "").strip().lower()
-    if env_think:
-        think = env_think
+    # Preserve native types: TOML bool stays bool, env 'true'/'false' → bool,
+    # other env strings kept as str.  JSON serializer outputs bool as true/false.
+    think: str | bool | None = None
+    env_think_raw = os.environ.get("LLM_JUDGE_THINK", "").strip()
+    if env_think_raw:
+        if env_think_raw.lower() == "true":
+            think = True
+        elif env_think_raw.lower() == "false":
+            think = False
+        else:
+            think = env_think_raw
     elif "think" in file_cfg and file_cfg["think"] is not None:
-        think = str(file_cfg["think"]).strip().lower()
+        think = file_cfg["think"]
 
     return JudgeConfig(
         api_base=os.environ.get(

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f1863c1d2321e662602c1523f701f33c2d3a9f2b"
+commit = "04633c39741994c1f6dcc15a5691e60728edc0a7"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Add `max_tokens` config to `judge.toml` / env var `LLM_JUDGE_MAX_TOKENS` (default 200) — prevents thinking models (Gemma 4) from consuming the token budget before generating output
- Add optional `think` parameter config (`LLM_JUDGE_THINK`) for compatible LLM routers
- Both parameters flow through `_call_api()` into the request payload

Closes #58

## Test plan
- [ ] Verify `LLM_JUDGE_MAX_TOKENS=8192` propagates to payload
- [ ] Verify `LLM_JUDGE_THINK=true` injects into API request
- [ ] Verify boolean `think = true` in TOML is lowercased to `"true"`
- [ ] Verify default behavior (max_tokens=200, no think) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)