### PR TITLE
fix(evaluator): exclude operational params from refusal baseline cache key

### DIFF
--- a/src/heretic/evaluator.py
+++ b/src/heretic/evaluator.py
@@ -524,14 +524,11 @@ class Evaluator:
         return _hash_json(
             {
                 "enabled": True,
-                "api_base": config.api_base,
                 "models": list(config.models),
-                "batch_size": config.batch_size,
-                "concurrency": config.concurrency,
-                "timeout": config.timeout,
-                "max_retries": config.max_retries,
-                "pricing": config.pricing,
                 "system_prompt": config.system_prompt,
+                "max_tokens": config.max_tokens,
+                "think": config.think,
+                "fallback_policy": config.fallback_policy,
             }
         )
 


### PR DESCRIPTION
## Summary
- Remove operational parameters (api_base, batch_size, concurrency, timeout, max_retries, pricing, etc.) from the refusal baseline cache key in `_compute_judge_config_hash()`
- Add missing judgment-affecting fields (max_tokens, think, fallback_policy) that were not previously included
- Prevents unnecessary 10+ minute baseline recomputation when only the serving endpoint changes

Closes #64

## Test plan
- [ ] Start heretic with judge.toml pointing to endpoint A (e.g. Ollama localhost:11434)
- [ ] Let baseline complete
- [ ] Change judge.toml to endpoint B (e.g. vLLM localhost:8102) serving the same model
- [ ] Restart heretic — baseline should be cached (no recomputation)
- [ ] Change system_prompt or models in judge.toml — baseline should recompute

🤖 Generated with [Claude Code](https://claude.com/claude-code)